### PR TITLE
Add Intelisence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/) and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.html).
 
+## [0.1.3] - 2025-10-04
+### Added
+- Section heading IntelliSense completion provider (type `==` then space for valid section suggestions)
+
 ## [0.1.1] - 2025-10-03
 ### Added
 - wordpress.org tabbed preview theme (Description, Installation, FAQ, Screenshots, Changelog, Reviews placeholder)
@@ -27,4 +31,5 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/) a
 - Context menu integration across explorer, editor tab, and editor content
 - Custom parser for WordPress readme formatting (FAQ, changelog headers, etc.)
 
+[0.1.3]: https://github.com/soderlind/wordpress-readme-preview/compare/v0.1.1...v0.1.3
 [0.1.1]: https://github.com/soderlind/wordpress-readme-preview/compare/v0.1.0...v0.1.1

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A Visual Studio Code extension that provides live preview and validation for Wor
 ✅ **False Positive Prevention** - Accurate detection without hallucinated errors  
 ✅ **Tabbed wordpress.org Layout** - Authentic multi-tab presentation (Description, Installation, FAQ, Screenshots, Changelog)  
 ✅ **Accessible Screenshot Gallery** - Keyboard & screen reader friendly with thumbnails  
+✅ **Section Heading IntelliSense** - Type `==` then space for valid section name completions  
 
 ![Alt text](media/example.png)
 

--- a/example/readme.txt
+++ b/example/readme.txt
@@ -7,6 +7,7 @@ Stable tag: 1.5.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
+
 Run wp-cron on all public sites in a multisite network (REST API based). Formerly known as DSS Cron.
 
 == Description ==

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wordpress-readme-preview",
-	"version": "0.1.1",
+	"version": "0.1.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wordpress-readme-preview",
-			"version": "0.1.1",
+			"version": "0.1.3",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"marked": "^4.2.5"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "wordpress-readme-preview",
 	"displayName": "WordPress Readme Preview",
 	"description": "Preview WordPress readme.txt files with accurate rendering and validation",
-	"version": "0.1.1",
+	"version": "0.1.3",
 	"publisher": "persoderlind",
 	"engines": {
 		"vscode": "^1.74.0"


### PR DESCRIPTION
This pull request adds a new IntelliSense completion feature for WordPress readme section headings, updates documentation to reflect this enhancement, and bumps the extension version to 0.1.3. The new completion provider helps users quickly insert valid section headers by typing `==` followed by a space, improving usability and reducing formatting errors.

**Feature: Section Heading IntelliSense**
- Added a completion provider in `src/extension.ts` that suggests valid WordPress readme section headings (e.g., Description, Installation, FAQ) when the user types `==` at the start of a line. This ensures correct section formatting and streamlines editing.

**Documentation Updates**
- Updated `README.md` to mention the new Section Heading IntelliSense feature.
- Updated `CHANGELOG.md` to document the addition of the section heading IntelliSense completion provider and added a comparison link for version 0.1.3. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R10) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR34)

**Versioning**
- Bumped the extension version from 0.1.1 to 0.1.3 in `package.json`.

**Extension Integration**
- Registered the new completion provider in the extension activation logic.